### PR TITLE
[OCF-69] Use nginx from SCL, switch to CentOS 7

### DIFF
--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,7 +1,0 @@
-FROM nginx:1.11
-
-RUN mkdir -p /var/cache/nginx \
-  && chgrp -R 0 /var/cache/nginx \
-  && chmod -R g+rwX /var/cache/nginx \
-  && chgrp -R 0 /var/run \
-  && chmod -R g+rwX /var/run

--- a/persistent-template.yml
+++ b/persistent-template.yml
@@ -1097,7 +1097,8 @@ objects:
         containers:
         - name: nginx
           imagePullPolicy: IfNotPresent
-          image: projectodd/whisk_nginx:${PROJECTODD_VERSION}
+          # Image from Mar 22nd
+          image: centos/nginx-112-centos7@sha256:42330f7f29ba1ad67819f4ff3ae2472f62de13a827a74736a5098728462212e7
           command: [ "/bin/bash", "-o", "allexport", "/nginx_config/init" ]
           env:
           - name: KUBERNETES_NAMESPACE

--- a/template.yml
+++ b/template.yml
@@ -1077,7 +1077,8 @@ objects:
         containers:
         - name: nginx
           imagePullPolicy: IfNotPresent
-          image: projectodd/whisk_nginx:${PROJECTODD_VERSION}
+          # Image from Mar 22nd
+          image: centos/nginx-112-centos7@sha256:42330f7f29ba1ad67819f4ff3ae2472f62de13a827a74736a5098728462212e7
           command: [ "/bin/bash", "-o", "allexport", "/nginx_config/init" ]
           env:
           - name: KUBERNETES_NAMESPACE


### PR DESCRIPTION
https://issues.jboss.org/browse/OCF-69

This image was tested by recreating the project entirely and executing the test script. Nothing failed, so I assume that the CentOS image is a drop-in replacement.