### PR TITLE
OCF-89: Set the JVM in the java 8 action runtime to obey cgroup memory limits

### DIFF
--- a/docker/runtimes/action-java-8/Dockerfile
+++ b/docker/runtimes/action-java-8/Dockerfile
@@ -22,4 +22,4 @@ RUN chgrp -R 0 /opt/jboss \
 
 USER 1000
 
-CMD ["java", "-jar", "/opt/jboss/javaAction-all.jar"]
+CMD ["java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-jar", "/opt/jboss/javaAction-all.jar"]


### PR DESCRIPTION
Options per [Oracle's documented flags](https://blogs.oracle.com/java-platform-group/java-se-support-for-docker-cpu-and-memory-limits)