### PR TITLE
Create learn-template.yml

### DIFF
--- a/learn-template.yml
+++ b/learn-template.yml
@@ -1,0 +1,1618 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: openwhisk-ephemeral
+  annotations:
+    openshift.io/display-name: Apache OpenWhisk (Ephemeral)
+    description: Apache OpenWhisk serverless platform, without persistent storage. You can leave all parameters blank and sensible defaults will be used.
+    iconClass: icon-apache
+    tags: serverless, openwhisk
+    openshift.io/long-description: This template provides a small OpenWhisk installation specifically for the katacode/learn scenarios. Data is not stored on persistent storage, so any restart of the service will result in all data being lost.
+    openshift.io/provider-display-name: Red Hat, Inc.
+    openshift.io/documentation-url: https://github.com/projectodd/openwhisk-openshift/
+    openshift.io/support-url: https://github.com/projectodd/openwhisk-openshift/issues
+message: "To get started download the `wsk` CLI from https://github.com/apache/incubator-openwhisk-cli/releases/\n\nYour OpenWhisk authentication token: ${WHISK_SYSTEM_AUTH}\n\nYour OpenWhisk api endpoint can be found in the console UI after closing the template wizard.\n\nConfigure your `wsk` client with `wsk property set --auth <your_auth> --apihost <your_apihost>`"
+labels:
+  template: openwhisk-ephemeral-template
+
+parameters:
+- name: CONTROLLER_INSTANCES
+  description: The desired number of controllers
+  value: "1"
+  required: true
+- name: CONTROLLER_MEMORY_REQUEST
+  description: The minimum container memory for each Controller
+  value: "512Mi"
+  required: true
+- name: CONTROLLER_MEMORY_LIMIT
+  description: The maximum container memory for each Controller
+  value: "512Mi"
+  required: true
+- name: CONTROLLER_JAVA_OPTS
+  description: JVM options to pass to the Controller - recommended to set at least Xmx here
+  value: "-Xmx256m"
+  required: true
+- name: CONTROLLER_HA
+  description: Boolean denoting whether HA mode
+  value: "FALSE"
+  required: true
+- name: CONTROLLER_LOCALBOOKKEEPING
+  description: Boolean denoting whether load balancer data is local or shared
+  value: "TRUE"
+  required: true
+- name: AKKA_CLUSTER_SEED_NODES
+  description: Hostnames of akka seed nodes
+  value: "controller-0.controller:2551"
+  required: true
+- name: INVOKER_INSTANCES
+  description: The desired number of invokers
+  value: "1"
+  required: true
+- name: INVOKER_CPU_REQUEST
+  description: The minimum cpu cores for each Invoker
+  value: "500m"
+  required: true
+- name: INVOKER_MEMORY_REQUEST
+  description: The minimum container memory for each Invoker
+  value: "1Gi"
+  required: true
+- name: INVOKER_MEMORY_LIMIT
+  description: The maximum container memory for each Invoker
+  value: "1Gi"
+  required: true
+- name: INVOKER_JAVA_OPTS
+  description: JVM options to pass to the Invoker - recommended to set at least Xmx here
+  value: "-Xmx512m"
+  required: true
+- name: INVOKER_MAX_CONTAINERS
+  description: Maximum function containers per Invoker
+  value: "8"
+  required: true
+- name : INVOKER_CONTAINER_TIMEOUT
+  description: Maximum time an idle function container should stick around before the Invoker deletes it. The longer the timeout, the longer functions stay warm. The shorter the timeout, the less resources consumed by idle function containers. Example values - "5 minutes", "30 seconds", etc.
+  value: "2 minutes"
+  required: true
+- name: INVOKER_CONTAINER_PAUSE_TIMEOUT
+  description: Maximum time an idle function container should stick around before the Invoker marks it as paused. Example values - "5 seconds", "500 milliseconds", etc.
+  value: "5 seconds"
+  required: true
+- name: COUCHDB_INSTANCES
+  description: The desired number of CouchDB nodes
+  value: "1"
+  required: true
+- name: COUCHDB_CPU_REQUEST
+  description: The minimum cpu cores for each CouchDB
+  value: "500m"
+  required: true
+- name: COUCHDB_MEMORY_REQUEST
+  description: The minimum container memory for each CouchDB
+  value: "256Mi"
+  required: true
+- name: COUCHDB_MEMORY_LIMIT
+  description: The maximum container memory for each CouchDB
+  value: "512Mi"
+  required: true
+- name: COUCHDB_USER
+  description: CouchDB Username
+  generate: expression
+  from: "user[A-Z0-9]{3}"
+  required: true
+- name: COUCHDB_PASSWORD
+  description: CouchDB Password
+  generate: expression
+  from: "[a-zA-Z0-9]{16}"
+  required: true
+- name: COUCHDB_SECRET
+  description: CouchDB Replication Secret
+  generate: expression
+  from: "[a-zA-Z0-9]{16}"
+  required: true
+- name: ZOOKEEPER_NODE_COUNT
+  description: Number of Zookeper cluster nodes which will be deployed (odd number of nodes is recomended)
+  displayName: Number of Zookeper cluster nodes (odd number of nodes is recomended)
+  required: true
+  value: "1"
+- name: KAFKA_NODE_COUNT
+  description: Number of Kafka cluster nodes which will be deployed
+  displayName: Number of Kafka cluster nodes
+  required: true
+  value: "1"
+- name: WHISK_SYSTEM_AUTH
+  description: OpenWhisk Auth token for whisk.system account
+  generate: expression
+  from: "789c46b1-71f6-4ed5-8c54-816aa4f8c502:[a-zA-Z0-9]{64}"
+  required: true
+- name: WHISK_GUEST_AUTH
+  description: OpenWhisk Auth token for guest account
+  generate: expression
+  from: "23bc46b1-71f6-4ed5-8c54-816aa4f8c502:[a-zA-Z0-9]{64}"
+  required: true
+- name: WHISK_ACTIONS_INVOKES_CONCURRENT
+  description: Default number of concurrenct actions per user
+  value: "30"
+  required: true
+- name: WHISK_ACTIONS_INVOKES_CONCURRENT_IN_SYSTEM
+  description: Number of concurrent actions allowed across the entire system
+  value: "1000"
+  required: true
+- name: WHISK_ACTIONS_INVOKES_PER_MINUTE
+  description: Default number of action invocations per minute per user
+  value: "60"
+  required: true
+- name: WHISK_TRIGGERS_FIRES_PER_MINUTE
+  description: Default number of triggers that can fire per minute per user
+  value: "60"
+  required: true
+- name: WHISK_DAYS_TO_KEEP_LOGS
+  description: Number of days to keep activation logs before pruning them from the database
+  value: "7"
+  required: true
+- name: WHISK_DAYS_TO_KEEP_ACTIVATIONS
+  description: Number of days to keep activation records before pruning them from the database
+  value: "30"
+  required: true
+- name: PROJECTODD_LEARN_TAG
+  description: The DockerHub tag for all images
+  value: "learn"
+  required: true
+
+objects:
+
+- apiVersion: "v1"
+  kind: "ImageStream"
+  metadata:
+    name: "cluster-controller"
+  spec:
+    dockerImageRepository: "docker.io/projectodd/cluster-controller"
+    lookupPolicy:
+      local: true
+    tags:
+    - from:
+        kind: DockerImage
+        name: docker.io/projectodd/cluster-controller:${PROJECTODD_LEARN_TAG}
+      name: ${PROJECTODD_LEARN_TAG}
+      referencePolicy:
+        type: Local
+- apiVersion: "v1"
+  kind: "ImageStream"
+  metadata:
+    name: "controller"
+  spec:
+    dockerImageRepository: "docker.io/projectodd/controller"
+    lookupPolicy:
+      local: true
+    tags:
+    - from:
+        kind: DockerImage
+        name: docker.io/projectodd/controller:${PROJECTODD_LEARN_TAG}
+      name: ${PROJECTODD_LEARN_TAG}
+      referencePolicy:
+        type: Local
+- apiVersion: "v1"
+  kind: "ImageStream"
+  metadata:
+    name: "invoker"
+  spec:
+    dockerImageRepository: "docker.io/projectodd/invoker"
+    lookupPolicy:
+      local: true
+    tags:
+    - from:
+        kind: DockerImage
+        name: docker.io/projectodd/invoker:${PROJECTODD_LEARN_TAG}
+      name: ${PROJECTODD_LEARN_TAG}
+      referencePolicy:
+        type: Local
+- apiVersion: "v1"
+  kind: "ImageStream"
+  metadata:
+    name: "action-nodejs-6"
+  spec:
+    dockerImageRepository: "docker.io/projectodd/action-nodejs-6"
+    lookupPolicy:
+      local: true
+    tags:
+    - from:
+        kind: DockerImage
+        name: docker.io/projectodd/action-nodejs-6:${PROJECTODD_LEARN_TAG}
+      name: ${PROJECTODD_LEARN_TAG}
+      referencePolicy:
+        type: Local
+- apiVersion: "v1"
+  kind: "ImageStream"
+  metadata:
+    name: "action-nodejs-8"
+  spec:
+    dockerImageRepository: "docker.io/projectodd/action-nodejs-8"
+    lookupPolicy:
+      local: true
+    tags:
+    - from:
+        kind: DockerImage
+        name: docker.io/projectodd/action-nodejs-8:${PROJECTODD_LEARN_TAG}
+      name: ${PROJECTODD_LEARN_TAG}
+      referencePolicy:
+        type: Local
+- apiVersion: "v1"
+  kind: "ImageStream"
+  metadata:
+    name: "action-java-8"
+  spec:
+    dockerImageRepository: "docker.io/projectodd/action-java-8"
+    lookupPolicy:
+      local: true
+    tags:
+    - from:
+        kind: DockerImage
+        name: docker.io/projectodd/action-java-8:${PROJECTODD_LEARN_TAG}
+      name: ${PROJECTODD_LEARN_TAG}
+      referencePolicy:
+        type: Local
+- apiVersion: "v1"
+  kind: "ImageStream"
+  metadata:
+    name: "action-python-3"
+  spec:
+    dockerImageRepository: "docker.io/projectodd/action-python-3"
+    lookupPolicy:
+      local: true
+    tags:
+    - from:
+        kind: DockerImage
+        name: docker.io/projectodd/action-python-3:${PROJECTODD_LEARN_TAG}
+      name: ${PROJECTODD_LEARN_TAG}
+      referencePolicy:
+        type: Local
+- apiVersion: "v1"
+  kind: "ImageStream"
+  metadata:
+    name: "action-python-2"
+  spec:
+    dockerImageRepository: "docker.io/projectodd/action-python-2"
+    lookupPolicy:
+      local: true
+    tags:
+    - from:
+        kind: DockerImage
+        name: docker.io/projectodd/action-python-2:${PROJECTODD_LEARN_TAG}
+      name: ${PROJECTODD_LEARN_TAG}
+      referencePolicy:
+        type: Local
+- apiVersion: "v1"
+  kind: "ImageStream"
+  metadata:
+    name: "action-php-7"
+  spec:
+    dockerImageRepository: "docker.io/projectodd/action-php-7"
+    lookupPolicy:
+      local: true
+    tags:
+    - from:
+        kind: DockerImage
+        name: docker.io/projectodd/action-php-7:${PROJECTODD_LEARN_TAG}
+      name: ${PROJECTODD_LEARN_TAG}
+      referencePolicy:
+        type: Local
+- apiVersion: "v1"
+  kind: "ImageStream"
+  metadata:
+    name: "action-swift-3"
+  spec:
+    dockerImageRepository: "docker.io/projectodd/action-swift-3"
+    lookupPolicy:
+      local: true
+    tags:
+    - from:
+        kind: DockerImage
+        name: docker.io/projectodd/action-swift-3:${PROJECTODD_LEARN_TAG}
+      name: ${PROJECTODD_LEARN_TAG}
+      referencePolicy:
+        type: Local        
+- apiVersion: "v1"
+  kind: "ImageStream"
+  metadata:
+    name: "couchdb"
+  spec:
+    dockerImageRepository: "docker.io/projectodd/whisk_couchdb"
+    lookupPolicy:
+      local: true
+    tags:
+    - from:
+        kind: DockerImage
+        name: docker.io/projectodd/whisk_couchdb:${PROJECTODD_LEARN_TAG}
+      name: ${PROJECTODD_LEARN_TAG}
+      referencePolicy:
+        type: Local
+- apiVersion: "v1"
+  kind: "ImageStream"
+  metadata:
+    name: "alarms"
+  spec:
+    dockerImageRepository: "docker.io/projectodd/whisk_alarms"
+    lookupPolicy:
+      local: true
+    tags:
+    - from:
+        kind: DockerImage
+        name: docker.io/projectodd/whisk_alarms:${PROJECTODD_LEARN_TAG}
+      name: ${PROJECTODD_LEARN_TAG}
+      referencePolicy:
+        type: Local
+- apiVersion: "v1"
+  kind: "ImageStream"
+  metadata:
+    name: "alarmprovider"
+  spec:
+    dockerImageRepository: "docker.io/projectodd/alarmprovider"
+    lookupPolicy:
+      local: true
+    tags:
+    - from:
+        kind: DockerImage
+        name: docker.io/projectodd/alarmprovider:${PROJECTODD_LEARN_TAG}
+      name: ${PROJECTODD_LEARN_TAG}
+      referencePolicy:
+        type: Local
+- apiVersion: "v1"
+  kind: "ImageStream"
+  metadata:
+    name: "catalog"
+  spec:
+    dockerImageRepository: "docker.io/projectodd/whisk_catalog"
+    lookupPolicy:
+      local: true
+    tags:
+    - from:
+        kind: DockerImage
+        name: docker.io/projectodd/whisk_catalog:${PROJECTODD_LEARN_TAG}
+      name: ${PROJECTODD_LEARN_TAG}
+      referencePolicy:
+        type: Local
+- apiVersion: "v1"
+  kind: "ImageStream"
+  metadata:
+    name: "busybox"
+  spec:
+    dockerImageRepository: "docker.io/projectodd/busybox"
+    lookupPolicy:
+      local: true
+    tags:
+    - from:
+        kind: DockerImage
+        name: docker.io/projectodd/busybox:${PROJECTODD_LEARN_TAG}
+      name: ${PROJECTODD_LEARN_TAG}
+      referencePolicy:
+        type: Local
+
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: whisk.config
+  data:
+    whisk_system_namespace: /whisk.system
+    whisk_version_date: 2018-01-01T00:00:00Z
+    whisk_version_name: OpenWhisk
+    whisk_version_tag: latest
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    creationTimestamp: null
+    name: whisk.limits
+  data:
+    actions_invokes_concurrent: "${WHISK_ACTIONS_INVOKES_CONCURRENT}"
+    actions_invokes_concurrentInSystem: "${WHISK_ACTIONS_INVOKES_CONCURRENT_IN_SYSTEM}"
+    actions_invokes_perMinute: "${WHISK_ACTIONS_INVOKES_PER_MINUTE}"
+    actions_sequence_maxLength: "50"
+    triggers_fires_perMinute: "${WHISK_TRIGGERS_FIRES_PER_MINUTE}"
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: whisk.runtimes
+  data:
+    runtimes: |
+      {
+          "bypassPullForLocalImages": false,
+          "defaultImagePrefix": "projectodd",
+          "defaultImageTag": "${PROJECTODD_LEARN_TAG}",
+          "runtimes": {
+              "nodejs": [
+                  {
+                      "kind": "nodejs",
+                      "image": {
+                          "name": "action-nodejs-6"
+                      },
+                      "deprecated": true
+                  },
+                  {
+                      "kind": "nodejs:6",
+                      "default": true,
+                      "image": {
+                          "name": "action-nodejs-6"
+                      },
+                      "deprecated": false
+                  },
+                  {
+                      "kind": "nodejs:8",
+                      "default": false,
+                      "image": {
+                          "name": "action-nodejs-8"
+                      },
+                      "deprecated": false
+                  }
+              ],
+              "python": [
+                  {
+                      "kind": "python",
+                      "image": {
+                          "name": "action-python-2"
+                      },
+                      "deprecated": false
+                  },
+                  {
+                      "kind": "python:2",
+                      "default": true,
+                      "image": {
+                          "name": "action-python-2"
+                      },
+                      "deprecated": false
+                  },
+                  {
+                      "kind": "python:3",
+                      "image": {
+                          "name": "action-python-3"
+                      },
+                      "deprecated": false
+                  }
+              ],
+              "swift": [
+                  {
+                      "kind": "swift",
+                      "image": {
+                          "name": "action-swift-3"
+                      },
+                      "deprecated": true
+                  },
+                  {
+                      "kind": "swift:3",
+                      "image": {
+                          "name": "action-swift-3"
+                      },
+                      "deprecated": true
+                  },
+                  {
+                      "kind": "swift:3.1.1",
+                      "default": true,
+                      "image": {
+                          "name": "action-swift-3"
+                      },
+                      "deprecated": false
+                  }
+              ],
+              "java": [
+                  {
+                      "kind": "java",
+                      "default": true,
+                      "image": {
+                          "name": "action-java-8"
+                      },
+                      "deprecated": false,
+                      "attached": {
+                          "attachmentName": "jarfile",
+                          "attachmentType": "application/java-archive"
+                      },
+                      "sentinelledLogs": false,
+                      "requireMain": true
+                  }
+              ],
+              "php": [
+                  {
+                      "kind": "php:7.1",
+                      "default": true,
+                      "deprecated": false,
+                      "image": {
+                          "name": "action-php-7"
+                      }
+                  }
+              ]
+          },
+          "blackboxes": [
+              {
+                  "name": "projectodd/dockerskeleton"
+              }
+          ]
+      }
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: strimzi-openwhisk
+    labels:
+      strimzi.io/type: kafka
+      strimzi.io/kind: cluster
+  data:
+    kafka-nodes: "${KAFKA_NODE_COUNT}"
+    kafka-image: "projectodd/kafka:${PROJECTODD_LEARN_TAG}"
+    kafka-healthcheck-delay: "15"
+    kafka-healthcheck-timeout: "5"
+    zookeeper-nodes: "${ZOOKEEPER_NODE_COUNT}"
+    zookeeper-image: "projectodd/zookeeper:${PROJECTODD_LEARN_TAG}"
+    zookeeper-healthcheck-delay: "15"
+    zookeeper-healthcheck-timeout: "5"
+    KAFKA_DEFAULT_REPLICATION_FACTOR: "${KAFKA_NODE_COUNT}"
+    KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "${KAFKA_NODE_COUNT}"
+    KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: "${KAFKA_NODE_COUNT}"
+    kafka-storage: |-
+      { "type": "ephemeral" }
+    zookeeper-storage: |-
+      { "type": "ephemeral" }
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: controller
+    labels:
+      name: controller
+  spec:
+    selector:
+      name: controller
+    clusterIP: None
+    ports:
+      - port: 8080
+        targetPort: 8080
+        name: http
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: controller.config
+  data:
+    controller_opts: "-Dwhisk.spi.LoadBalancerProvider=whisk.core.loadBalancer.ShardingContainerPoolBalancer"
+    java_opts: "${CONTROLLER_JAVA_OPTS}"
+- apiVersion: apps/v1beta1
+  kind: StatefulSet
+  metadata:
+    name: controller
+    annotations:
+      template.alpha.openshift.io/wait-for-ready: "true"
+    labels:
+      name: controller
+  spec:
+    replicas: ${CONTROLLER_INSTANCES}
+    serviceName: "controller"
+    template:
+      metadata:
+        labels:
+          name: controller
+      spec:
+        restartPolicy: Always
+        containers:
+        - name: controller
+          imagePullPolicy: IfNotPresent
+          image: controller:${PROJECTODD_LEARN_TAG}
+          command: ["/bin/bash", "-c", "COMPONENT_NAME=$(hostname | cut -d'-' -f2) CONFIG_akka_remote_netty_tcp_hostname=$(hostname).controller /init.sh `hostname | cut -d'-' -f2`"]
+          ports:
+          - name: controller
+            containerPort: 8080
+          - name: akka
+            containerPort: 2551
+          resources:
+            requests:
+              memory: ${CONTROLLER_MEMORY_REQUEST}
+            limits:
+              memory: ${CONTROLLER_MEMORY_LIMIT}
+          env:
+          # Properties for controller HA configuration
+          # Must change these if changing number of replicas
+          - name: "CONTROLLER_LOCALBOOKKEEPING"
+            value: ${CONTROLLER_LOCALBOOKKEEPING}
+          - name: "CONTROLLER_HA"
+            value: ${CONTROLLER_HA}
+          - name: "CONTROLLER_INSTANCES"
+            value: ${CONTROLLER_INSTANCES}
+          - name: "AKKA_CLUSTER_SEED_NODES"
+            value: ${AKKA_CLUSTER_SEED_NODES}
+          - name: "CONFIG_akka_actor_provider"
+            value: "cluster"
+          - name: "CONFIG_akka_remote_netty_tcp_bindPort"
+            value: "2551"
+          - name: "CONFIG_akka_remote_netty_tcp_port"
+            value: "2551"
+          - name: "CONFIG_whisk_loadbalancer_invokerBusyThreshold"
+            value: "${INVOKER_MAX_CONTAINERS}"
+  
+          # extra JVM arguments
+          - name: "JAVA_OPTS"
+            valueFrom:
+              configMapKeyRef:
+                name: controller.config
+                key: java_opts
+  
+          # extra controller arguments
+          - name: "CONTROLLER_OPTS"
+            valueFrom:
+              configMapKeyRef:
+                name: controller.config
+                key: controller_opts
+  
+          # action runtimes
+          - name: "RUNTIMES_MANIFEST"
+            valueFrom:
+              configMapKeyRef:
+                name: whisk.runtimes
+                key: runtimes
+  
+          # deployment version information
+          - name:  "WHISK_VERSION_NAME"
+            valueFrom:
+              configMapKeyRef:
+                name: whisk.config
+                key: whisk_version_name
+          - name:  "WHISK_VERSION_DATE"
+            valueFrom:
+              configMapKeyRef:
+                name: whisk.config
+                key: whisk_version_date
+          - name: "WHISK_VERSION_BUILDNO"
+            valueFrom:
+              configMapKeyRef:
+                name: whisk.config
+                key: whisk_version_tag
+  
+          # specify limits
+          - name: "LIMITS_ACTIONS_INVOKES_PERMINUTE"
+            valueFrom:
+              configMapKeyRef:
+                name: whisk.limits
+                key: actions_invokes_perMinute
+          - name: "LIMITS_ACTIONS_INVOKES_CONCURRENT"
+            valueFrom:
+              configMapKeyRef:
+                name: whisk.limits
+                key: actions_invokes_concurrent
+          - name: "LIMITS_ACTIONS_INVOKES_CONCURRENTINSYSTEM"
+            valueFrom:
+              configMapKeyRef:
+                name: whisk.limits
+                key: actions_invokes_concurrentInSystem
+          - name: "LIMITS_TRIGGERS_FIRES_PERMINUTE"
+            valueFrom:
+              configMapKeyRef:
+                name: whisk.limits
+                key: triggers_fires_perMinute
+          - name: "LIMITS_ACTIONS_SEQUENCE_MAXLENGTH"
+            valueFrom:
+              configMapKeyRef:
+                name: whisk.limits
+                key: actions_sequence_maxLength
+  
+          # properties for Kafka connection
+          - name: "KAFKA_HOSTS"
+            value: "$(STRIMZI_OPENWHISK_KAFKA_SERVICE_HOST):$(STRIMZI_OPENWHISK_KAFKA_SERVICE_PORT_CLIENTS)"
+  
+          # properties for DB connection
+          - name: "CONFIG_whisk_couchdb_username"
+            valueFrom:
+              secretKeyRef:
+                name: db.auth
+                key: db_username
+          - name: "CONFIG_whisk_couchdb_password"
+            valueFrom:
+              secretKeyRef:
+                name: db.auth
+                key: db_password
+          - name:  "CONFIG_whisk_couchdb_protocol"
+            valueFrom:
+              configMapKeyRef:
+                name: db.config
+                key: db_protocol
+          - name: "CONFIG_whisk_couchdb_host"
+            value: "$(COUCHDB_SERVICE_HOST)"
+          - name: "CONFIG_whisk_couchdb_port"
+            value: "$(COUCHDB_SERVICE_PORT_COUCHDB)"
+          - name: "CONFIG_whisk_couchdb_provider"
+            valueFrom:
+              configMapKeyRef:
+                name: db.config
+                key: db_provider
+          - name: "CONFIG_whisk_couchdb_databases_WhiskActivation"
+            valueFrom:
+              configMapKeyRef:
+                name: db.config
+                key: db_whisk_activations
+          - name: "CONFIG_whisk_couchdb_databases_WhiskEntity"
+            valueFrom:
+              configMapKeyRef:
+                name: db.config
+                key: db_whisk_actions
+          - name: "CONFIG_whisk_couchdb_databases_WhiskAuth"
+            valueFrom:
+              configMapKeyRef:
+                name: db.config
+                key: db_whisk_auths
+  
+          # must match port used in livenessProbe below
+          - name: "PORT"
+            value: "8080"
+  
+          livenessProbe:
+            httpGet:
+              path: "/ping"
+              port: 8080
+              scheme: "HTTP"
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: "/ping"
+              port: 8080
+              scheme: "HTTP"
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 10
+            failureThreshold: 5
+        initContainers:
+        - name: wait-for-services
+          image: busybox:${PROJECTODD_LEARN_TAG}
+          command: ['sh', '-cu', 'until nslookup couchdb && nslookup strimzi-openwhisk-kafka; do echo waiting for services; sleep 1; done']
+        - name: wait-for-couchdb
+          image: busybox:${PROJECTODD_LEARN_TAG}
+          command: ['sh', '-c', 'until wget -T 5 --spider http://${COUCHDB_SERVICE_HOST}:${COUCHDB_SERVICE_PORT}/${DB_WHISK_ACTIVATIONS}; do echo waiting for couchdb; sleep 2; done;']
+          env:
+          - name: "DB_WHISK_ACTIVATIONS"
+            valueFrom:
+              configMapKeyRef:
+                name: db.config
+                key: db_whisk_activations
+- apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: install-catalog
+  spec:
+    activeDeadlineSeconds: 600
+    template:
+      metadata:
+        name: install-catalog
+      spec:
+        containers:
+        - name: catalog
+          image: catalog:${PROJECTODD_LEARN_TAG}
+          env:
+            - name: "WHISK_AUTH"
+              valueFrom:
+                secretKeyRef:
+                  name: whisk.auth
+                  key: system
+            - name: "WHISK_API_HOST_NAME"
+              value: "http://controller:8080"
+        initContainers:
+        - name: wait-for-controller
+          image: busybox:${PROJECTODD_LEARN_TAG}
+          command: ['sh', '-c', 'until wget -T 5 --spider http://controller:8080/ping; do echo waiting for controller; sleep 2; done;']
+        restartPolicy: Never
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: couchdb
+    labels:
+      name: couchdb
+  spec:
+    selector:
+      name: couchdb
+    ports:
+      - port: 5984
+        targetPort: 5984
+        name: couchdb
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: couchdb-headless
+    labels:
+      name: couchdb-headless
+  spec:
+    selector:
+      name: couchdb
+    ports:
+    - name: couchdb
+      port: 5984
+    clusterIP: None
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: db.config
+  data:
+    db_prefix: test_
+    db_protocol: http
+    db_provider: CouchDB
+    db_whisk_actions: test_whisks
+    db_whisk_activations: test_activations
+    db_whisk_auths: test_subjects
+    db_days_to_keep_logs: "${WHISK_DAYS_TO_KEEP_LOGS}"
+    db_days_to_keep_activations: "${WHISK_DAYS_TO_KEEP_ACTIVATIONS}"
+- apiVersion: apps/v1beta1
+  kind: StatefulSet
+  metadata:
+    name: couchdb
+    labels:
+      name: couchdb
+  spec:
+    replicas: ${COUCHDB_INSTANCES}
+    serviceName: couchdb-headless
+    template:
+      metadata:
+        labels:
+          name: couchdb
+      spec:
+        restartPolicy: Always
+        volumes:
+        - name: couchdb-data
+          emptyDir: {}
+        containers:
+        - name: couchdb
+          imagePullPolicy: IfNotPresent
+          image: couchdb:${PROJECTODD_LEARN_TAG}
+          command: ["/init.sh"]
+          ports:
+          - name: couchdb
+            containerPort: 5984
+          - name: epmd
+            containerPort: 4369
+          - containerPort: 9100
+          resources:
+            requests:
+              cpu: "${COUCHDB_CPU_REQUEST}"
+              memory: ${COUCHDB_MEMORY_REQUEST}
+            limits:
+              memory: ${COUCHDB_MEMORY_LIMIT}
+          env:
+          - name: "DB_PREFIX"
+            valueFrom:
+              configMapKeyRef:
+                name: db.config
+                key: db_prefix
+          - name: "DB_HOST"
+            value: "127.0.0.1"
+          - name: "DB_PORT"
+            value: "$(COUCHDB_SERVICE_PORT_COUCHDB)"
+          - name: "COUCHDB_USER"
+            valueFrom:
+              secretKeyRef:
+                name: db.auth
+                key: db_username
+          - name: "COUCHDB_PASSWORD"
+            valueFrom:
+              secretKeyRef:
+                name: db.auth
+                key: db_password
+          - name: "COUCHDB_SECRET"
+            valueFrom:
+              secretKeyRef:
+                name: db.auth
+                key: db_secret
+          - name: "NODENAME_HOSTNAME"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: "NODENAME_SUBDOMAIN"
+            value: "couchdb-headless"
+          - name: "COUCHDB_NODE_COUNT"
+            value: "${COUCHDB_INSTANCES}"
+          - name: "AUTH_WHISK_SYSTEM"
+            valueFrom:
+              secretKeyRef:
+                name: whisk.auth
+                key: system
+          - name: "AUTH_GUEST"
+            valueFrom:
+              secretKeyRef:
+                name: whisk.auth
+                key: guest
+          volumeMounts:
+          - name: couchdb-data
+            mountPath: "/opt/couchdb/data"
+          readinessProbe:
+            httpGet:
+              port: 5984
+              path: "/_utils/"
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 10
+            timeoutSeconds: 1
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: invoker.config
+  data:
+    docker_image_prefix: ""
+    docker_image_tag: ${PROJECTODD_LEARN_TAG}
+    docker_registry: ""
+    invoker_container_dns: ""
+    invoker_container_network: bridge
+    invoker_logs_dir: ""
+    invoker_opts: "-Dwhisk.spi.ContainerFactoryProvider=whisk.core.containerpool.kubernetes.KubernetesContainerFactoryProvider"
+    invoker_use_runc: "false"
+    java_opts: "${INVOKER_JAVA_OPTS}"
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: invoker
+  data:
+    init: |
+      export COMPONENT_NAME=$(hostname | cut -d'-' -f2)
+      # Dynamically determine API gateway host
+      export TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+      export NAMESPACE="$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)"
+      export APIGW_HOST=$(curl -s --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H "Authorization: Bearer ${TOKEN}" "https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/oapi/v1/namespaces/${NAMESPACE}/routes/openwhisk?pretty=true" | grep '"host":' | head -n 1 | awk -F '"' '{print $4}')
+      export APIGW_HOST_V2=${APIGW_HOST}
+      export WHISK_API_HOST_NAME=${APIGW_HOST}
+      exec /init.sh
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: openwhisk
+- apiVersion: v1
+  kind: RoleBinding
+  metadata:
+    name: openwhisk
+  roleRef:
+    name: edit
+  subjects:
+    - kind: ServiceAccount
+      name: openwhisk
+- apiVersion: apps/v1beta1
+  kind: StatefulSet
+  metadata:
+    name: invoker
+    labels:
+      name: invoker
+  spec:
+    replicas: ${INVOKER_INSTANCES}
+    serviceName: "invoker"
+    template:
+      metadata:
+        labels:
+          name: invoker
+      spec:
+        restartPolicy: Always
+        volumes:
+        - name: invoker-config
+          configMap:
+            name: invoker
+        serviceAccountName: openwhisk
+  
+        initContainers:
+        - name: wait-for-services
+          image: busybox:${PROJECTODD_LEARN_TAG}
+          command: ['sh', '-cu', 'until nslookup couchdb && nslookup strimzi-openwhisk-zookeeper && nslookup strimzi-openwhisk-kafka; do echo waiting for services; sleep 1; done']
+        - name: wait-for-controller
+          image: busybox:${PROJECTODD_LEARN_TAG}
+          command: ['sh', '-c', 'until wget -T 5 --spider http://controller:8080/ping; do echo waiting for controller; sleep 2; done;']
+  
+        containers:
+        - name: invoker
+          imagePullPolicy: IfNotPresent
+          image: invoker:${PROJECTODD_LEARN_TAG}
+          command: [ "/bin/bash", "-o", "allexport", "/invoker_config/init" ]
+          ports:
+          - name: invoker
+            containerPort: 8080
+          resources:
+            requests:
+              cpu: "${INVOKER_CPU_REQUEST}"
+              memory: ${INVOKER_MEMORY_REQUEST}
+            limits:
+              memory: ${INVOKER_MEMORY_LIMIT}
+          volumeMounts:
+          - name: invoker-config
+            mountPath: "/invoker_config"
+          env:
+            - name: "PORT"
+              value: "8080"
+  
+            # Generate stable invoker names from the StatefulSet names
+            - name: "INVOKER_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+  
+            # Docker-related options
+            - name: "INVOKER_CONTAINER_NETWORK"
+              valueFrom:
+                configMapKeyRef:
+                  name: invoker.config
+                  key: invoker_container_network
+            - name: "INVOKER_CONTAINER_DNS"
+              valueFrom:
+                configMapKeyRef:
+                  name: invoker.config
+                  key: invoker_container_dns
+            - name: "INVOKER_USE_RUNC"
+              valueFrom:
+                configMapKeyRef:
+                  name: invoker.config
+                  key: invoker_use_runc
+            - name: "INVOKER_CORESHARE"
+              value: "1"
+            - name: "INVOKER_NUMCORE"
+              value: "${INVOKER_MAX_CONTAINERS}"
+            - name: "CONFIG_whisk_containerProxy_timeouts_idleContainer"
+              value: "${INVOKER_CONTAINER_TIMEOUT}"
+            - name: "CONFIG_whisk_containerProxy_timeouts_pauseGrace"
+              value: "${INVOKER_CONTAINER_PAUSE_TIMEOUT}"
+            - name: "DOCKER_IMAGE_PREFIX"
+              valueFrom:
+                configMapKeyRef:
+                  name: invoker.config
+                  key: docker_image_prefix
+            - name: "DOCKER_IMAGE_TAG"
+              valueFrom:
+                configMapKeyRef:
+                  name: invoker.config
+                  key: docker_image_tag
+            - name: "DOCKER_REGISTRY"
+              valueFrom:
+                configMapKeyRef:
+                  name: invoker.config
+                  key: docker_registry
+  
+            # action runtimes
+            - name: "RUNTIMES_MANIFEST"
+              valueFrom:
+                configMapKeyRef:
+                  name: whisk.runtimes
+                  key: runtimes
+  
+            # extra JVM arguments
+            - name: "JAVA_OPTS"
+              valueFrom:
+                configMapKeyRef:
+                  name: invoker.config
+                  key: java_opts
+  
+            # extra Invoker arguments
+            - name: "INVOKER_OPTS"
+              valueFrom:
+                configMapKeyRef:
+                  name: invoker.config
+                  key: invoker_opts
+  
+            # Recommend using "" because logs should go to stdout on kube
+            - name: "WHISK_LOGS_DIR"
+              valueFrom:
+                configMapKeyRef:
+                  name: invoker.config
+                  key: invoker_logs_dir
+  
+            # properties for Kafka connection
+            - name: "KAFKA_HOSTS"
+              value: "$(STRIMZI_OPENWHISK_KAFKA_SERVICE_HOST):$(STRIMZI_OPENWHISK_KAFKA_SERVICE_PORT_CLIENTS)"
+  
+            # properties for zookeeper connection
+            - name: "ZOOKEEPER_HOSTS"
+              value: "$(STRIMZI_OPENWHISK_ZOOKEEPER_SERVICE_HOST):$(STRIMZI_OPENWHISK_ZOOKEEPER_SERVICE_PORT_CLIENTS)"
+  
+            # properties for DB connection
+            - name: "CONFIG_whisk_couchdb_username"
+              valueFrom:
+                secretKeyRef:
+                  name: db.auth
+                  key: db_username
+            - name: "CONFIG_whisk_couchdb_password"
+              valueFrom:
+                secretKeyRef:
+                  name: db.auth
+                  key: db_password
+            - name:  "CONFIG_whisk_couchdb_protocol"
+              valueFrom:
+                configMapKeyRef:
+                  name: db.config
+                  key: db_protocol
+            - name: "CONFIG_whisk_couchdb_host"
+              value: "$(COUCHDB_SERVICE_HOST)"
+            - name: "CONFIG_whisk_couchdb_port"
+              value: "$(COUCHDB_SERVICE_PORT_COUCHDB)"
+            - name: "CONFIG_whisk_couchdb_provider"
+              valueFrom:
+                configMapKeyRef:
+                  name: db.config
+                  key: db_provider
+            - name: "CONFIG_whisk_couchdb_databases_WhiskActivation"
+              valueFrom:
+                configMapKeyRef:
+                  name: db.config
+                  key: db_whisk_activations
+            - name: "CONFIG_whisk_couchdb_databases_WhiskEntity"
+              valueFrom:
+                configMapKeyRef:
+                  name: db.config
+                  key: db_whisk_actions
+            - name: "CONFIG_whisk_couchdb_databases_WhiskAuth"
+              valueFrom:
+                configMapKeyRef:
+                  name: db.config
+                  key: db_whisk_auths
+            - name: CONFIG_whisk_kubernetes_namespace
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+
+            # Increase Kube API timeouts until we handle timeouts nicer
+            - name: "CONFIG_whisk_kubernetes_timeouts_run"
+              value: "10 minutes"
+            - name: "CONFIG_whisk_kubernetes_timeouts_rm"
+              value: "10 minutes"
+            - name: "CONFIG_whisk_kubernetes_timeouts_logs"
+              value: "10 minutes"
+
+            # Uncomment the below to stop fetching action logs and
+            # greatly increase throughput if you don't need them
+            # - name: "CONFIG_whisk_spi_LogStoreProvider"
+            #   value: "whisk.core.containerpool.logging.LogDriverLogStoreProvider"
+- apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: preload-openwhisk-runtimes
+    labels:
+      name: preload-openwhisk-runtimes
+  spec:
+    completions: 1
+    serviceAccountName: openwhisk
+    template:
+      metadata:
+        labels:
+          name: preload-openwhisk-runtimes
+      spec:
+        restartPolicy: Never
+        initContainers:
+        - name: preload-openwhisk-nodejs6
+          image: action-nodejs-6:${PROJECTODD_LEARN_TAG}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c", "echo", "success"]
+        - name: preload-openwhisk-java8
+          image: action-java-8:${PROJECTODD_LEARN_TAG}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c", "echo", "success"]
+        - name: preload-openwhisk-python3
+          image: action-python-3:${PROJECTODD_LEARN_TAG}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c", "echo", "success"]
+        - name: preload-openwhisk-python2
+          image: action-python-2:${PROJECTODD_LEARN_TAG}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c", "echo", "success"]
+        - name: preload-openwhisk-php7
+          image: action-php-7:${PROJECTODD_LEARN_TAG}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c", "echo", "success"]
+        - name: preload-openwhisk-swift3
+          image: action-swift-3:${PROJECTODD_LEARN_TAG}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c", "echo", "success"]
+        containers:
+        - name: preload-openwhisk-nodejs8
+          image: action-nodejs-8:${PROJECTODD_LEARN_TAG}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c", "echo", "success"]
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: nginx
+    labels:
+      name: nginx
+  spec:
+    type: NodePort
+    selector:
+      name: nginx
+    ports:
+      - port: 80
+        targetPort: 8080
+        name: http
+      - port: 8443
+        targetPort: 8443
+        name: https-admin
+- apiVersion: v1
+  kind: Route
+  metadata:
+    name: openwhisk
+    annotations:
+      template.openshift.io/expose-apihost: "{.spec.host}"
+    labels:
+      name: nginx
+  spec:
+    port:
+      targetPort: http
+    to:
+      kind: Service
+      name: nginx
+      weight: 100
+    wildcardPolicy: None
+    tls:
+      termination: edge
+      insecureEdgeTerminationPolicy: Redirect
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: nginx
+  data:
+    init: |
+      cp /nginx_config/nginx.conf /tmp/nginx.conf
+      sed -i "s/<kubernetes_service_host>/$(grep nameserver /etc/resolv.conf | head -1 | awk '{print $2}')/" /tmp/nginx.conf
+      sed -i "s/<kubernetes_namespace>/${KUBERNETES_NAMESPACE}/" /tmp/nginx.conf
+      exec nginx -c /tmp/nginx.conf -g "daemon off;"
+    nginx.conf: |
+      worker_rlimit_nofile 4096;
+  
+      events {
+          worker_connections  4096;
+      }
+  
+      http {
+          client_max_body_size 50M;
+  
+          rewrite_log on;
+          log_format combined-upstream '$remote_addr - $remote_user [$time_local] '
+              '$request $status $body_bytes_sent '
+              '$http_referer $http_user_agent $upstream_addr';
+          access_log /logs/nginx_access.log combined-upstream;
+          error_log /logs/nginx_error.log;
+
+          proxy_http_version 1.1;
+          proxy_set_header Connection "";
+  
+          server {
+              listen 8080 default;
+
+              # Make sure nginx dynamically resolves dns entries
+              # instead of resolving once and caching that result
+              # forever
+              resolver <kubernetes_service_host>;
+              set $controller controller.<kubernetes_namespace>.svc.cluster.local;
+  
+              # match namespace, note while OpenWhisk allows a richer character set for a
+              # namespace, not all those characters are permitted in the (sub)domain name;
+              # if namespace does not match, no vanity URL rewriting takes place.
+              server_name ~^(?<namespace>[0-9a-zA-Z-]+)\.localhost$;
+  
+              # proxy to the web action path
+              location / {
+                  if ($namespace) {
+                    rewrite    /(.*) /api/v1/web/${namespace}/$1 break;
+                  }
+                  proxy_pass http://$controller:8080;
+                  proxy_read_timeout 75s; # 70+5 additional seconds to allow controller to terminate request
+              }
+  
+              # proxy to 'public/html' web action by convention
+              location = / {
+                  if ($namespace) {
+                    rewrite    ^ /api/v1/web/${namespace}/public/index.html break;
+                  }
+                  proxy_pass http://$controller:8080;
+                  proxy_read_timeout 75s; # 70+5 additional seconds to allow controller to terminate request
+              }
+  
+              location /blackbox.tar.gz {
+                  return 301 https://github.com/apache/incubator-openwhisk-runtime-docker/releases/download/sdk%400.1.0/blackbox-0.1.0.tar.gz;
+              }
+              # leaving this for a while for clients out there to update to the new endpoint
+              location /blackbox-0.1.0.tar.gz {
+                  return 301 /blackbox.tar.gz;
+              }
+  
+              location /OpenWhiskIOSStarterApp.zip {
+                  return 301 https://github.com/openwhisk/openwhisk-client-swift/releases/download/0.2.3/starterapp-0.2.3.zip;
+              }
+  
+              # redirect requests for specific binaries to the matching one from the latest openwhisk-cli release.
+              location /cli/go/download/linux/amd64 {
+                  return 301 https://github.com/apache/incubator-openwhisk-cli/releases/download/latest/OpenWhisk_CLI-latest-linux-amd64.tgz;
+              }
+              location /cli/go/download/linux/386 {
+                  return 301 https://github.com/apache/incubator-openwhisk-cli/releases/download/latest/OpenWhisk_CLI-latest-linux-386.tgz;
+              }
+              location /cli/go/download/mac/amd64 {
+                  return 301 https://github.com/apache/incubator-openwhisk-cli/releases/download/latest/OpenWhisk_CLI-latest-mac-amd64.zip;
+              }
+              location /cli/go/download/mac/386 {
+                  return 301 https://github.com/apache/incubator-openwhisk-cli/releases/download/latest/OpenWhisk_CLI-latest-mac-386.zip;
+              }
+              location /cli/go/download/windows/amd64 {
+                  return 301 https://github.com/apache/incubator-openwhisk-cli/releases/download/latest/OpenWhisk_CLI-latest-windows-amd64.zip;
+              }
+              location /cli/go/download/windows/386 {
+                  return 301 https://github.com/apache/incubator-openwhisk-cli/releases/download/latest/OpenWhisk_CLI-latest-windows-386.zip;
+              }
+  
+              # redirect top-level cli downloads to the latest openwhisk-cli release.
+              location /cli/go/download {
+                  return 301 https://github.com/apache/incubator-openwhisk-cli/releases/latest;
+               }
+          }
+      }
+- apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    name: nginx
+    annotations:
+      template.alpha.openshift.io/wait-for-ready: "true"
+    labels:
+      name: nginx
+  spec:
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          name: nginx
+      spec:
+        restartPolicy: Always
+        volumes:
+        - name: nginx-conf
+          configMap:
+            name: nginx
+        - name: logs
+          emptyDir: {}
+        containers:
+        - name: nginx
+          imagePullPolicy: IfNotPresent
+          image: projectodd/nginx:${PROJECTODD_LEARN_TAG}
+          command: [ "/bin/bash", "-o", "allexport", "/nginx_config/init" ]
+          env:
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          ports:
+          - name: http
+            containerPort: 8080
+          - name: https-admin
+            containerPort: 8443
+          volumeMounts:
+          - name: nginx-conf
+            mountPath: "/nginx_config"
+          - name: logs
+            mountPath: "/logs"
+        initContainers:
+        - name: wait-for-controller
+          image: busybox:${PROJECTODD_LEARN_TAG}
+          command: ['sh', '-c', 'until wget -T 5 --spider http://controller:8080/ping; do echo waiting for controller; sleep 2; done;']
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: whisk.auth
+    annotations:
+      template.openshift.io/expose-auth: "{.data['system']}"
+  stringData:
+    guest: "${WHISK_GUEST_AUTH}"
+    system: "${WHISK_SYSTEM_AUTH}"
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: db.auth
+  stringData:
+    db_username: "${COUCHDB_USER}"
+    db_password: "${COUCHDB_PASSWORD}"
+    db_secret: "${COUCHDB_SECRET}"
+- apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    name: strimzi-cluster-controller
+  spec:
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          name: strimzi-cluster-controller
+      spec:
+        serviceAccountName: openwhisk
+        containers:
+        - name: strimzi-cluster-controller
+          image: cluster-controller:${PROJECTODD_LEARN_TAG}
+          env:
+          - name: STRIMZI_CONFIGMAP_LABELS
+            value: "strimzi.io/kind=cluster"
+          - name: STRIMZI_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: STRIMZI_OPERATION_TIMEOUT_MS
+            value: "600000"
+          livenessProbe:
+            httpGet:
+              path: /healthy
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 30
+        initContainers:
+        - name: preload-strimzi-zookeeper
+          image: projectodd/zookeeper:${PROJECTODD_LEARN_TAG}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c", "echo", "success"]
+        - name: preload-strimzi-kafka
+          image: projectodd/kafka:${PROJECTODD_LEARN_TAG}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c", "echo", "success"]
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: alarmprovider
+  data:
+    PORT: "8080"
+    DB_PREFIX: "whisk_alarms_"
+    CONTROLLER_HOST: "controller"
+    CONTROLLER_PORT: "8080"
+    env: |
+      export TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+      export NAMESPACE="$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)"
+      export ROUTER_HOST=$(curl -s --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H "Authorization: Bearer ${TOKEN}" "https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/oapi/v1/namespaces/${NAMESPACE}/routes/openwhisk?pretty=true" | grep '"host":' | head -n 1 | awk -F '"' '{print $4}')
+- apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    name: alarmprovider
+    labels:
+      name: alarmprovider
+  spec:
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          name: alarmprovider
+      spec:
+        restartPolicy: Always
+        serviceAccountName: openwhisk
+        volumes:
+        - name: alarmprovider-config
+          configMap:
+            name: alarmprovider
+        containers:
+        - name: alarmprovider
+          imagePullPolicy: IfNotPresent
+          image: alarmprovider:${PROJECTODD_LEARN_TAG}
+          command: [ "/bin/bash", "-c", "source /alarmprovider_config/env; node /alarmsTrigger/app.js" ]
+          envFrom:
+          - configMapRef:
+              name: alarmprovider
+          env:
+          - name: "DB_HOST"
+            value: "$(COUCHDB_SERVICE_HOST):$(COUCHDB_SERVICE_PORT_COUCHDB)"
+          - name:  "DB_PROTOCOL"
+            valueFrom:
+              configMapKeyRef:
+                name: db.config
+                key: db_protocol
+          - name: "DB_USERNAME"
+            valueFrom:
+              secretKeyRef:
+                name: db.auth
+                key: db_username
+          - name: "DB_PASSWORD"
+            valueFrom:
+              secretKeyRef:
+                name: db.auth
+                key: db_password
+          volumeMounts:
+          - name: alarmprovider-config
+            mountPath: "/alarmprovider_config"
+        initContainers:
+        - name: wait-for-couchdb
+          image: busybox:${PROJECTODD_LEARN_TAG}
+          command: ['sh', '-cu', 'echo "$COUCHDB_SERVICE_HOST"']
+        - name: install-alarms-catalog
+          imagePullPolicy: IfNotPresent
+          image: alarms:${PROJECTODD_LEARN_TAG}
+          envFrom:
+          - configMapRef:
+              name: alarmprovider
+          env:
+          - name: "DB_HOST"
+            value: "$(COUCHDB_SERVICE_HOST):$(COUCHDB_SERVICE_PORT_COUCHDB)"
+          - name:  "DB_PROTOCOL"
+            valueFrom:
+              configMapKeyRef:
+                name: db.config
+                key: db_protocol
+          - name: "AUTH_WHISK_SYSTEM"
+            valueFrom:
+              secretKeyRef:
+                name: whisk.auth
+                key: system
+          volumeMounts:
+          - name: alarmprovider-config
+            mountPath: "/alarmprovider_config"
+- apiVersion: batch/v2alpha1
+  kind: CronJob
+  metadata:
+    name: refresh-activations
+    labels:
+      name: refresh-activations
+  spec:
+    schedule: "*/5 * * * *"
+    concurrencyPolicy: Forbid
+    successfulJobsHistoryLimit: 1
+    failedJobsHistoryLimit: 1
+    jobTemplate:
+      spec:
+        template:
+          metadata:
+            labels:
+              parent: "cronjob-refresh-activations"
+          spec:
+            serviceAccountName: openwhisk
+            restartPolicy: Never
+            containers:
+            - name: refresh-activations
+              image: alarms:${PROJECTODD_LEARN_TAG}
+              command: ["/bin/bash", "-c", "/openwhisk/bin/wsk --auth $AUTH_GUEST --apihost http://controller:8080 -i activation list"]
+              env:
+              - name: "AUTH_GUEST"
+                valueFrom:
+                  secretKeyRef:
+                    name: whisk.auth
+                    key: guest
+            initContainers:
+            - name: wait-for-controller
+              image: busybox:${PROJECTODD_LEARN_TAG}
+              command: ['sh', '-c', 'until wget -T 5 --spider http://controller:8080/ping; do echo waiting for controller; sleep 2; done;']
+              restartPolicy: Never
+- apiVersion: batch/v2alpha1
+  kind: CronJob
+  metadata:
+    name: prune-activations
+    labels:
+      name: prune-activations
+  spec:
+    schedule: "0 0 * * *"
+    concurrencyPolicy: Forbid
+    successfulJobsHistoryLimit: 1
+    failedJobsHistoryLimit: 1
+    jobTemplate:
+      spec:
+        template:
+          metadata:
+            labels:
+              parent: "cronjob-prune-activations"
+          spec:
+            restartPolicy: Never
+            containers:
+            - name: refresh-activations
+              image: couchdb:${PROJECTODD_LEARN_TAG}
+              command: ["/bin/bash", "-c", "set -x; /openwhisk/tools/db/deleteLogsFromActivations.py --dbUrl http://$DB_USERNAME:$DB_PASSWORD@$COUCHDB_SERVICE_HOST:$COUCHDB_SERVICE_PORT_COUCHDB --dbName $DB_ACTIVATIONS --days $DB_DAYS_TO_KEEP_LOGS; /openwhisk/tools/db/cleanUpActivations.py --dbUrl http://$DB_USERNAME:$DB_PASSWORD@$COUCHDB_SERVICE_HOST:$COUCHDB_SERVICE_PORT_COUCHDB --dbName $DB_ACTIVATIONS --days $DB_DAYS_TO_KEEP_ACTIVATIONS"]
+              env:
+              - name: "DB_USERNAME"
+                valueFrom:
+                  secretKeyRef:
+                    name: db.auth
+                    key: db_username
+              - name: "DB_PASSWORD"
+                valueFrom:
+                  secretKeyRef:
+                    name: db.auth
+                    key: db_password
+              - name: "DB_ACTIVATIONS"
+                valueFrom:
+                  configMapKeyRef:
+                    name: db.config
+                    key: db_whisk_activations
+              - name: "DB_DAYS_TO_KEEP_LOGS"
+                valueFrom:
+                  configMapKeyRef:
+                    name: db.config
+                    key: db_days_to_keep_logs
+              - name: "DB_DAYS_TO_KEEP_ACTIVATIONS"
+                valueFrom:
+                  configMapKeyRef:
+                    name: db.config
+                    key: db_days_to_keep_activations
+            initContainers:
+            - name: wait-for-couchdb
+              image: busybox:${PROJECTODD_LEARN_TAG}
+              command: ['sh', '-c', 'until wget -T 5 --spider http://${COUCHDB_SERVICE_HOST}:${COUCHDB_SERVICE_PORT}/${DB_WHISK_ACTIVATIONS}; do echo waiting for couchdb; sleep 2; done;']
+              env:
+              - name: "DB_WHISK_ACTIVATIONS"
+                valueFrom:
+                  configMapKeyRef:
+                    name: db.config
+                    key: db_whisk_activations


### PR DESCRIPTION
This is a new template that we will use for the katacoda/learn environment.  It uses a stable set of images that are tagged in projectodd with the learn tag.  This will allow the katacoda/learn env to pre-pull these images into the openshift-3-7 environment so the setup of openwhisk for each scenario will hopefully take less time.